### PR TITLE
Fix convert_type_to_float

### DIFF
--- a/preprocess_mimiciii.py
+++ b/preprocess_mimiciii.py
@@ -81,7 +81,7 @@ def get_ICD9s_from_mimic_file(fileName, hadmToMap):
 
 def convert_type_to_float(type):
 	#very specific to Mimic-III ADMISSIONS.csv
-	code = 0
+	code = 4
 	if type == 'NEWBORN': code = 0
 	elif type == 'ELECTIVE': code = 1
 	elif type == 'EMERGENCY': code = 2


### PR DESCRIPTION
The previous version was considering all the 'problematic codes' as NEWBORN, chose 4 rather than the usal -1 in case of chosing for indexing tables & didn't want to change the others.
![image](https://github.com/jfrjunio/LIG-Doctor/assets/56939432/ff7ecfc4-2015-4eec-8804-b94bda2437f8)
